### PR TITLE
Minor fixes

### DIFF
--- a/src/Scheme/Evaluator.hs
+++ b/src/Scheme/Evaluator.hs
@@ -139,8 +139,8 @@ cdr badArgList = throwError $ NumArgs 1 badArgList
 
 cons :: [LispVal] -> ThrowsError LispVal
 cons [x1, List []] = return $ List [x1]
-cons [x, List xs] = return $ List $ [x] ++ xs
-cons [x, DottedList xs xlast] = return $ DottedList ([x] ++ xs) xlast
+cons [x, List xs] = return $ List $ x : xs
+cons [x, DottedList xs xlast] = return $ DottedList (x : xs) xlast
 cons [x1, x2] = return $ DottedList [x1] x2
 cons badArgList = throwError $ NumArgs 2 badArgList
 

--- a/src/Scheme/Parser.hs
+++ b/src/Scheme/Parser.hs
@@ -16,6 +16,9 @@ import Scheme.Types
 symbol :: Parser Char
 symbol = oneOf "!$%&|*+-/:<=>?@^_~#"
 
+between' :: Char -> Char -> Parser a -> Parser a
+between' open close = between (char open) (char close)
+
 readOrThrow :: Parser a -> String -> ThrowsError a
 readOrThrow parser input = case parse parser "lisp" input of
     Left err -> throwError $ Parser err
@@ -28,10 +31,7 @@ readExpr = readOrThrow parseExpr
 readExprList = readOrThrow (endBy parseExpr spaces)
 
 parseString :: Parser LispVal
-parseString = do char '"'
-                 x <- many (noneOf "\"")
-                 char '"'
-                 return $ String x
+parseString = between' '"' '"' $ liftM String $ many (noneOf "\"")
 
 parseAtom :: Parser LispVal
 parseAtom = do first <- letter <|> symbol
@@ -67,8 +67,5 @@ parseExpr = parseAtom
         <|> parseString
         <|> parseNumber
         <|> parseQuoted
-        <|> do char '('
-               x <- (try parseList) <|> parseDottedList
-               char ')'
-               return x
+        <|> (between' '(' ')' $ (try parseList) <|> parseDottedList)
 

--- a/src/Scheme/Parser.hs
+++ b/src/Scheme/Parser.hs
@@ -36,7 +36,7 @@ parseString = between' '"' '"' $ liftM String $ many (noneOf "\"")
 parseAtom :: Parser LispVal
 parseAtom = do first <- letter <|> symbol
                rest <- many (letter <|> digit <|> symbol)
-               let atom = [first] ++ rest
+               let atom = first : rest
                return $ case atom of
                           "#t" -> Bool True
                           "#f" -> Bool False


### PR DESCRIPTION
- `[x] ++ xs`처럼 쓰인 부분을 `x : xs`로 수정했습니다. 혹시 기존에 `++`를 사용하신 이유가 있으셨다면 빼겠습니다.
- `()`나 `""`로 둘러쌓인 부분을 일반화하는 `between'` 함수를 정의했습니다.